### PR TITLE
Add CocoaPod support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ __Note for iOS:__ If your react-native version < 0.40 install with this tag inst
 ```
 npm install react-native-tcp@3.1.0 --save
 ```
+## if using Cocoapods
+
+Update the following line with your path to `node_modules/` and add it to your
+podfile:
+
+```ruby
+pod 'TcpSockets', :path => '../node_modules/react-native-tcp'
+```
 
 ## Link in the native dependency
 

--- a/TcpSockets.podspec
+++ b/TcpSockets.podspec
@@ -1,0 +1,23 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+
+  s.name           = 'TcpSockets'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.homepage       = package['repository']['url']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.source         = { :git => s.homepage, :tag => 'v#{s.version}' }
+
+  s.requires_arc   = true
+  s.ios.deployment_target = '8.0'
+  s.tvos.deployment_target = '9.0'
+
+  s.preserve_paths = 'README.md', 'package.json', '**/*.js'
+  s.source_files   = 'ios/**/*.{h,m}'
+  s.dependency 'React'
+
+end


### PR DESCRIPTION
The following code changes adds support for CocoPods, which is required for React-Native 60+ 